### PR TITLE
Fix incorrect behavior on i18n system

### DIFF
--- a/pacaur.py
+++ b/pacaur.py
@@ -58,7 +58,7 @@ class Pacaur(dotbot.Plugin):
         # Make sure we are sudo so we don't have any problems
         subprocess.call('sudo --validate', shell=True)
 
-        cmd = 'pacaur --needed --noconfirm --noedit -S {}'.format(pkg)
+        cmd = 'LANG=en_US.UTF-8 pacaur --needed --noconfirm --noedit -S {}'.format(pkg)
 
         self._log.info('Installing {}'.format(pkg))
 


### PR DESCRIPTION
Currently when using script on localized system, which makes pacaur to use non-english language, script not work as it searching for specific strings. Setting language to english for cmd fixes it.